### PR TITLE
feat: make cors as *

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/api/:path*',
+        headers: [
+          { key: 'Access-Control-Allow-Credentials', value: 'true' },
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET,OPTIONS,PATCH,DELETE,POST,PUT',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value:
+              'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
+          },
+        ],
+      },
+    ];
+  },
+};


### PR DESCRIPTION
Since we want origin set to `*`

We just have to create `next.config.js` and add the configuration.

added a `.gitignore` too 🙂

Previous PR is redundant.

Reference: https://vercel.com/support/articles/how-to-enable-cors