### PR TITLE
Fix error for demand & all combination with v1.1 API

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -13,7 +13,7 @@ const createQuery = (params) => {
   const oxygen_query = "oxygen OR oxygen%20cylinder OR oxygen%20cylinders";
   const hospital_query = "bed OR beds OR icu OR ambulance OR #bed OR #BED OR ventilator OR ventilators OR oxygen OR hospital OR plasma";
   const medicine_query = "medicine OR remdesivir OR favipiravir OR tocilizumab OR Fabilflu";
-  const vaccine_query = "vaccine OR pfizer OR covishield OR covaxin OR mRNA";
+  const vaccine_query = "vaccine OR covishield OR covaxin";
   const helpline_query = "helpline OR covid OR toll-free";
 
   let resource_type_query = "";
@@ -54,7 +54,7 @@ const createV1Query = (params) => {
   const oxygen_query = "oxygen OR oxygen%20cylinder OR oxygen%20cylinders";
   const hospital_query = "bed OR beds OR icu OR ambulance OR #bed OR #BED OR ventilator OR ventilators OR oxygen OR hospital OR plasma";
   const medicine_query = "medicine OR remdesivir OR favipiravir OR tocilizumab OR Fabilflu";
-  const vaccine_query = "vaccine OR pfizer OR covishield OR covaxin OR mRNA";
+  const vaccine_query = "vaccine OR covishield OR covaxin";
   const helpline_query = "helpline OR covid OR toll-free";
 
 


### PR DESCRIPTION
V1.1 API fails when `material_type` is `all` and `resource_type` is `demand` due to long query per https://twittercommunity.com/t/error-code-195-missing-or-invalid-url-parameter-status-403/131057
This PR fixes that bug.